### PR TITLE
fix: MD037/no-space-in-emphasis

### DIFF
--- a/meetings/2014/LDM-2014-02-17.md
+++ b/meetings/2014/LDM-2014-02-17.md
@@ -204,7 +204,7 @@ Open question: should you be allowed a separator before the numeric-type-suffix?
 
 
 # 11. Binary literals
-*Approved. Already in preview. Aligns with C# vNext feature "binary literals" *
+*Approved. Already in preview. Aligns with C# vNext feature "binary literals"*
 
 It will be nice for enum literals. F# has them. We would ask the debugger to consider displaying stuff in binary as well, but that’s lower priority.
 ``` vb
@@ -214,7 +214,7 @@ It will be nice for enum literals. F# has them. We would ask the debugger to con
 Note: Integer.TryParse is a language-neutral .NET Framework function, that should not be augmented just for sake of new language-syntax. So we wouldn't want to make it work with the above syntax.
 
 # 12. Multiline strings
-*Approved. Already in preview. Parity with C#. *
+*Approved. Already in preview. Parity with C#.*
 
 ``` vb
    Dim x = "Hello
@@ -338,7 +338,7 @@ But it's better than nothing, and brings more regularity into the language.
 
 
 # 16. <field:attr> on autoprops
-*Approved. Aligns with C# vNext feature "field target on autoprops" *
+*Approved. Aligns with C# vNext feature "field target on autoprops"*
 ``` vb
    <field:attr> property x As Integer
    <field:attr> event e As Action

--- a/meetings/2014/LDM-2014-10-01.md
+++ b/meetings/2014/LDM-2014-10-01.md
@@ -38,7 +38,7 @@ _Resolution: Option4_. This is the most helpful to developers. You might wonder 
 
 __Piecewise initialization of structs__. In the code above, do we allow `z.z1 = 15` to assign to the _field_ of a readonly struct autoprop?
 _Option1:_ Yes by threating access to "z" for purposes of definite assignment as an access of the underlying field.
-_Option2: _ No because in `z.z1` the read of `z` happens via the accessor as per the principle above, and thus returns an rvalue, and hence assignment to `z.z1` can't work. Instead you will have to write `z = new Z(...)`.
+_Option2:_ No because in `z.z1` the read of `z` happens via the accessor as per the principle above, and thus returns an rvalue, and hence assignment to `z.z1` can't work. Instead you will have to write `z = new Z(...)`.
 _Resolution: Option2_. If we went with Option1, then readonly autoprops would end up being more expressive than settable autoprops which would be odd! Note that in VB you can still write `_z.z1 = 15` if you do want piecewise assignment.
 
 __Virtual__. What should happen if the readonly autoprop is virtual, and its getter is overridden in a derived class?


### PR DESCRIPTION

Spaces inside emphasis markers