### PR TITLE
US 1583733 Add missing language IDs - 63

### DIFF
--- a/spec/conversions.md
+++ b/spec/conversions.md
@@ -303,7 +303,7 @@ End Module
 
 The output of the program is:
 
-```
+```console
 Values: 0, 123
 Refs: 123, 123
 ```
@@ -337,7 +337,7 @@ End Module
 
 The output of the program is:
 
-```
+```console
 Values: 123, 123
 ```
 
@@ -401,7 +401,7 @@ End Module
 
 The first call to `Increment` modifies the value in the variable `x`. This is not equivalent to the second call to `Increment`, which modifies the value in a boxed copy of `x`. Thus, the output of the program is:
 
-```
+```console
 0
 1
 1

--- a/spec/expressions.md
+++ b/spec/expressions.md
@@ -253,7 +253,7 @@ End Module
 
 This code displays:
 
-```
+```console
 Early-bound: xy
 Late-bound: yx
 ```
@@ -289,7 +289,7 @@ End Module
 
 This code displays:
 
-```
+```console
 F(Base)
 F(Derived)
 ```
@@ -471,7 +471,7 @@ End Module
 
 The resulting output is:
 
-```
+```console
 Int32
 Int32
 String
@@ -659,7 +659,7 @@ End Module
 
 This code prints out:
 
-```
+```console
 MoreDerived.F
 Derived.F
 Derived.F
@@ -1926,7 +1926,7 @@ End Module
 
 It prints the following result:
 
-```
+```console
 System.Int16 = 512
 ```
 
@@ -2694,7 +2694,7 @@ End Module
 
 It prints the following result:
 
-```
+```console
 And: False True
 Or: True False
 AndAlso: False
@@ -2892,7 +2892,7 @@ End Module
 
 will print out:
 
-```
+```console
 2 4 6 8
 ```
 
@@ -3109,13 +3109,13 @@ End Module
 
 prints
 
-```
+```console
 1 2 3 4 5 6 7 8 9 10
 ```
 
 instead of
 
-```
+```console
 9 9 9 9 9 9 9 9 9 9
 ```
 

--- a/spec/general-concepts.md
+++ b/spec/general-concepts.md
@@ -521,7 +521,7 @@ End Module
 
 There are two `Overridable` methods here: one introduced by class `A` and the one introduced by class `C`. The method introduced by class `C` hides the method inherited from class `A`. Thus, the `Overrides` declaration in class `D` overrides the method introduced by class `C`, and it is not possible for class `D` to override the method introduced by class `A`. The example produces the output:
 
-```
+```console
 B.F
 B.F
 D.F
@@ -770,7 +770,7 @@ End Module
 
 This example prints:
 
-```
+```console
 TestDerived.DerivedTest1
 TestBase.Test2
 ```

--- a/spec/overload-resolution.md
+++ b/spec/overload-resolution.md
@@ -121,7 +121,7 @@ Given a method group, the most applicable method in the group for an argument li
 
         The above example produces the following output:
 
-        ```
+        ```console
         F(Object, Object())
         F(Object, Object, Object())
         F(Object, Object, Object())
@@ -506,7 +506,7 @@ End Module
 
 The above example produces the following output:
 
-```
+```console
 System.Int32 System.String System.Double
 System.Object[]
 System.Object[]

--- a/spec/statements.md
+++ b/spec/statements.md
@@ -414,7 +414,7 @@ End Module
 
 This program prints:
 
-```
+```console
 Static variable x = 5
 Static variable x = 6
 Static variable x = 7
@@ -890,7 +890,7 @@ End Module
 
 The expression `a(GetIndex())` is evaluated twice for simple assignment but only once for compound assignment, so the code prints:
 
-```
+```console
 Simple assignment
 Getting index
 Getting index
@@ -1138,7 +1138,7 @@ End Module
 
 The code prints:
 
-```
+```console
 x = 10
 ```
 
@@ -1185,7 +1185,7 @@ End Module
 
 The code produces the output:
 
-```
+```console
 31    32    33
 ```
 
@@ -1248,7 +1248,7 @@ End Module
 
 The code produces the output:
 
-```
+```console
 Second Loop
 ```
 
@@ -1592,7 +1592,7 @@ End Module
 
 This example prints:
 
-```
+```console
 Third handler
 ```
 
@@ -1791,7 +1791,7 @@ End Module
 
 It prints the following result.
 
-```
+```console
 Before exception
 Before exception
 After SyncLock
@@ -1925,7 +1925,7 @@ End Module
 
 It prints the following result:
 
-```
+```console
 3, 0
 ```
 

--- a/spec/type-members.md
+++ b/spec/type-members.md
@@ -334,7 +334,7 @@ End Module
 
 The output of the program is:
 
-```vb
+```console
 F()
 F(Integer)
 F(Object)
@@ -537,7 +537,7 @@ End Module
 
 In the example, class `Base` introduces a method `F` and an `Overridable` method `G`. The class `Derived` introduces a new method `F`, thus shadowing the inherited `F`, and also overrides the inherited method `G`. The example produces the following output:
 
-```
+```console
 Base.F
 Derived.F
 Derived.G
@@ -641,7 +641,7 @@ End Module
 
 The example produces the following output, even though the value parameter `p` is modified:
 
-```
+```console
 pre: a = 1
 p = 1
 post: a = 1
@@ -676,7 +676,7 @@ End Module
 
 The output of the program is:
 
-```
+```console
 pre: x = 1, y = 2
 post: x = 2, y = 1
 ```
@@ -757,7 +757,7 @@ End Module
 
 The output of the program is:
 
-```
+```console
 x = 10, y = 20
 x = 30, y = 40
 ```
@@ -802,7 +802,7 @@ End Module
 
 The example produces the output
 
-```
+```console
 Array contains 3 elements: 1 2 3
 Array contains 4 elements: 10 20 30 40
 Array contains 0 elements:
@@ -895,7 +895,7 @@ End Module
 
 This will print out:
 
-```
+```console
 Raised
 Raised
 ```
@@ -1229,7 +1229,7 @@ End Class
 
 When `New B()` is used to create an instance of `B`, the following output is produced:
 
-```
+```console
 x = 1, y = 1
 ```
 
@@ -1340,7 +1340,7 @@ End Class
 
 The output could be either of the following:
 
-```
+```console
 Init A
 A.F
 Init B
@@ -1349,7 +1349,7 @@ B.F
 
 or
 
-```
+```console
 Init B
 Init A
 A.F
@@ -1386,7 +1386,7 @@ End Class
 
 The output is:
 
-```
+```console
 Init B
 B.G
 ```
@@ -1409,7 +1409,7 @@ End Class
 
 This produces the output:
 
-```
+```console
 X = 1, Y = 2
 ```
 
@@ -1417,7 +1417,7 @@ To execute the `Main` method, the system first loads class `B`. The `Shared` con
 
 Had the `Main` method instead been located in class `A`, the example would have produced the following output:
 
-```
+```console
 X = 2, Y = 1
 ```
 
@@ -1857,7 +1857,7 @@ End Class
 
 Prints out:
 
-```
+```console
 1
 1
 2
@@ -2040,7 +2040,7 @@ End Module
 
 The example produces the following output:
 
-```
+```console
 x = 1.4142135623731, i = 100, s = Hello
 ```
 
@@ -2142,7 +2142,7 @@ End Module
 
 Because `b` is automatically initialized to its default value when the class is loaded and `i` is automatically initialized to its default value when an instance of the class is created, the preceding code produces the following output:
 
-```
+```console
 b = False, i = 0
 ```
 
@@ -2167,7 +2167,7 @@ End Module
 
 This program produces the output:
 
-```vb
+```console
 x = 10, y = 20
 ```
 
@@ -2767,7 +2767,7 @@ End Module
 
 This program will produce the output:
 
-```
+```console
 MoreDerived = 10
 Derived = 10
 Base = 10

--- a/spec/types.md
+++ b/spec/types.md
@@ -80,7 +80,7 @@ End Module
 
 The output of the program is:
 
-```
+```console
 Values: 0, 123
 Refs: 123, 123
 ```
@@ -385,7 +385,7 @@ End Module
 
 The example above prints the enumeration values and their associated values. The output is:
 
-```
+```console
 Red = 0
 Green = 10
 Blue = 11
@@ -988,7 +988,7 @@ End Module
 
 The program outputs the following:
 
-```
+```console
 arr(0) = 0
 arr(1) = 1
 arr(2) = 4


### PR DESCRIPTION
US 1583733 - Fix CATS P1 issues by adding missing language IDs to code blocks.
- Used "console" for sample program output displayed on the console.

Contributes to #2192