### PR TITLE
De-duplicate H1 headings

### DIFF
--- a/spec/attributes.md
+++ b/spec/attributes.md
@@ -1,4 +1,4 @@
-# Attributes
+# Attributes in Visual Basic
 
 The Visual Basic language enables the programmer to specify modifiers on declarations, which represent information about the entities being declared. For example, affixing a class method with the modifiers `Public`, `Protected`, `Friend`, `Protected Friend`, or `Private` specifies its accessibility.
 

--- a/spec/conversions.md
+++ b/spec/conversions.md
@@ -1,4 +1,4 @@
-# Conversions
+# Conversions in Visual Basic
 
 Conversion is the process of changing a value from one type to another. For example, a value of type `Integer` can be converted to a value of type `Double`, or a value of type `Derived` can be converted to a value of type `Base`, assuming that `Base` and `Derived` are both classes and `Derived` inherits from `Base`. Conversions may not require the value itself to change (as in the latter example), or they may require significant changes in the value representation (as in the former example).
 

--- a/spec/expressions.md
+++ b/spec/expressions.md
@@ -1,4 +1,4 @@
-# Expressions
+# Expressions in Visual Basic
 
 An expression is a sequence of operators and operands that specifies a computation of a value, or that designates a variable or constant. This chapter defines the syntax, order of evaluation of operands and operators, and meaning of expressions.
 

--- a/spec/introduction.md
+++ b/spec/introduction.md
@@ -1,4 +1,4 @@
-# Introduction
+# Introduction to Visual Basic
 
 The Microsoft&reg; Visual Basic&reg; programming language is a high-level programming language for the Microsoft .NET Framework. Although it is designed to be an approachable and easy-to-learn language, it is also powerful enough to satisfy the needs of experienced programmers. The Visual Basic programming language has a syntax that is similar to English, which promotes the clarity and readability of Visual Basic code. Wherever possible, meaningful words or phrases are used instead of abbreviations, acronyms, or special characters. Extraneous or unneeded syntax is generally allowed but not required.
 

--- a/spec/statements.md
+++ b/spec/statements.md
@@ -1,4 +1,4 @@
-# Statements
+# Statements in Visual Basic
 
 Statements represent executable code.
 

--- a/spec/types.md
+++ b/spec/types.md
@@ -1,4 +1,4 @@
-# Types
+# Types in Visual Basic
 
 The two fundamental categories of types in Visual Basic are *value types* and *reference types*. Primitive types (except strings), enumerations, and structures are value types. Classes, strings, standard modules, interfaces, arrays, and delegates are reference types.
 


### PR DESCRIPTION
The dotnet/csharplang and dotnet/vblang repos both publish to the docs.microsoft.com/dotnet URL/docset. Because there are articles in these two repos that have the same titles, e.g. "Attributes" and "Types", it's causing build warnings in the dotnet/docs repo. This PR resolves those build warnings.

Contributes to dotnet/docs#25322